### PR TITLE
ci: hygiene fixes — CLA @v2.6.1, dependabot skip, test-count parser sum

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,11 +16,12 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request_target') ||
-      (github.event_name == 'issue_comment' && github.event.comment.body == 'recheck')
+      github.actor != 'dependabot[bot]' &&
+      ((github.event_name == 'pull_request_target') ||
+      (github.event_name == 'issue_comment' && github.event.comment.body == 'recheck'))
     steps:
       - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2
+        uses: contributor-assistant/github-action@v2.6.1
         with:
           path-to-signatures: '.github/cla-signatures.json'
           path-to-document: 'https://github.com/${{ github.repository }}/blob/main/.github/CLA.md'

--- a/.github/workflows/pr-protection.yml
+++ b/.github/workflows/pr-protection.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 env:
   CARGO_TERM_COLOR: always
-  MIN_TEST_COUNT: 362
+  MIN_TEST_COUNT: 378
 
 jobs:
   security-scan:
@@ -50,7 +50,7 @@ jobs:
         run: |
           OUTPUT=$(cargo test 2>&1)
           echo "$OUTPUT"
-          PASSED=$(echo "$OUTPUT" | grep -oP '\d+ passed' | grep -oP '\d+' | tail -1)
+          PASSED=$(echo "$OUTPUT" | grep -oP '\d+ passed' | grep -oP '\d+' | awk '{s+=$1} END{print s+0}')
           echo "Tests passed: ${PASSED:-0}"
           if [ "${PASSED:-0}" -lt "$MIN_TEST_COUNT" ]; then
             echo "::error::Test count ${PASSED:-0} < minimum $MIN_TEST_COUNT"


### PR DESCRIPTION
## Summary

DIRECTIVE-FORGE-20260503-02, Step 1 of 6 (PR-A).

Three pre-existing CI failures surfaced by PR #16 review:

**Fix 1 — CLA action version** (`cla.yml`):
- `contributor-assistant/github-action@v2` tag was deleted upstream
- Bumped to `@v2.6.1` (latest stable, 2024-09-26)

**Fix 2 — Dependabot CLA skip** (`cla.yml`):
- Dependabot PRs were permanently failing CLA check (bots cannot sign CLAs)
- Added `github.actor != 'dependabot[bot]'` condition — dependabot PRs skip CLA entirely
- Unblocks PR #11 (rand) and PR #13 (rustls-webpki)

**Fix 3 — Test count parser** (`pr-protection.yml`):
- `tail -1` only captured the last test binary output (12 MCP tests)
- `cargo test` produces 3 result lines: 356 unit + 10 CLI + 12 MCP = 378 total
- Replaced with `awk '{s+=$1} END{print s+0}'` to sum all binaries
- Updated `MIN_TEST_COUNT: 362 → 378` (current actual count)

## Test plan

- [x] `cargo fmt --check` clean (pre-push CI gate)
- [x] `cargo check` clean
- [x] All 378 tests pass
- [ ] CI workflow changes only — no Rust code modified

🌽 Generated with NextGen AI - Intelligent Systems
https://nxtg.ai
Co-Authored-By: AxW <axw@nxtg.ai>