### PR TITLE
fix(deps): bump rustls-webpki 0.103.10 → 0.103.13 (3 RED advisories)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Closes 3 RED security advisories:
- RUSTSEC-2026-0104
- RUSTSEC-2026-0098
- RUSTSEC-2026-0099

**Why a new PR instead of merging #13**: PR #13 was branched before the clippy sweep (`1c418ed`). Its Lint CI was failing because the dependabot branch was missing those fixes. This branch is rebased onto current main — lint is clean.

**Cargo.lock change only** — identical to dependabot's original bump, just on a clean base.

## Test plan

- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo audit` — rustls-webpki advisories resolved; 4 remaining are pre-existing YELLOWs addressed in separate PRs
- [x] All 378 tests pass

🌽 Generated with NextGen AI - Intelligent Systems
https://nxtg.ai
Co-Authored-By: AxW <axw@nxtg.ai>